### PR TITLE
test: cover network retry and timeout scenarios

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
-"""
-Pytest configuration for aiochainscan tests.
-"""
+"""Pytest configuration for aiochainscan tests."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Awaitable, Iterator, TypeVar
 
 import pytest
 
@@ -45,3 +49,135 @@ def integration_test_setup():
     """Setup for integration tests - show API key status if needed."""
     # This fixture runs automatically for all test sessions
     pass
+
+
+T = TypeVar('T')
+
+
+@dataclass(slots=True)
+class FakeServer:
+    """Lightweight container describing the in-process aiohttp test server."""
+
+    base_url: str
+    state: dict[str, Any]
+    loop: asyncio.AbstractEventLoop
+
+    def run(self, coro: Awaitable[T]) -> T:
+        """Execute the given coroutine on the server's event loop."""
+
+        return self.loop.run_until_complete(coro)
+
+
+def _build_fake_app() -> Any:
+    """Create an aiohttp web application implementing deterministic endpoints."""
+
+    pytest.importorskip('aiohttp')
+    from aiohttp import web  # Lazy import to avoid hard dependency at import time
+
+    state: dict[str, Any] = {
+        '429_once': 0,
+        '429_sustained': 0,
+        'timeout': 0,
+        'forbidden': 0,
+        'ok_total': 0,
+        'ok_active': 0,
+        'ok_max': 0,
+    }
+
+    app = web.Application()
+    app['state'] = state
+    app['timeout_delay'] = 0.2
+    app['ok_delay'] = 0.05
+
+    async def handle_429_once(request: web.Request) -> web.Response:
+        state['429_once'] += 1
+        if state['429_once'] == 1:
+            return web.json_response(
+                {'status': '0', 'message': 'too many requests'},
+                status=429,
+                headers={'Retry-After': '1'},
+            )
+        return web.json_response({'status': '1', 'result': {'ok': True}})
+
+    async def handle_429_sustained(request: web.Request) -> web.Response:
+        state['429_sustained'] += 1
+        return web.json_response(
+            {'status': '0', 'message': 'limit'},
+            status=429,
+            headers={'Retry-After': '2'},
+        )
+
+    async def handle_timeout(request: web.Request) -> web.Response:
+        state['timeout'] += 1
+        await asyncio.sleep(app['timeout_delay'])
+        return web.json_response({'status': '1', 'result': 'slow'})
+
+    async def handle_forbidden(request: web.Request) -> web.Response:
+        state['forbidden'] += 1
+        return web.json_response({'status': '0', 'message': 'forbidden'}, status=403)
+
+    async def handle_ok(request: web.Request) -> web.Response:
+        state['ok_total'] += 1
+        state['ok_active'] += 1
+        state['ok_max'] = max(state['ok_max'], state['ok_active'])
+        try:
+            await asyncio.sleep(app['ok_delay'])
+            return web.json_response({'status': '1', 'result': {'value': state['ok_total']}})
+        finally:
+            state['ok_active'] -= 1
+
+    app.router.add_get('/429_once', handle_429_once)
+    app.router.add_get('/429_sustained', handle_429_sustained)
+    app.router.add_get('/timeout', handle_timeout)
+    app.router.add_get('/forbidden', handle_forbidden)
+    app.router.add_get('/ok', handle_ok)
+
+    return app
+
+
+@pytest.fixture
+def fake_app() -> Any:
+    """Provide the configured aiohttp application used by network retry tests."""
+
+    return _build_fake_app()
+
+
+@pytest.fixture
+def fake_server(fake_app: Any) -> Iterator[FakeServer]:
+    """Spin up an aiohttp server exposing deterministic retry/timeout behaviour."""
+
+    pytest.importorskip('aiohttp')
+    from aiohttp import web
+
+    loop = asyncio.new_event_loop()
+    try:
+        current_loop = asyncio.get_event_loop()
+    except RuntimeError:
+        current_loop = None
+    asyncio.set_event_loop(loop)
+
+    runner = web.AppRunner(fake_app)
+    loop.run_until_complete(runner.setup())
+    site = web.TCPSite(runner, '127.0.0.1', 0)
+    loop.run_until_complete(site.start())
+
+    sockets = getattr(site._server, 'sockets', None)
+    if not sockets:
+        raise RuntimeError('Failed to determine bound port for fake server')
+    port = sockets[0].getsockname()[1]
+
+    server = FakeServer(base_url=f'http://127.0.0.1:{port}', state=fake_app['state'], loop=loop)
+    try:
+        yield server
+    finally:
+        loop.run_until_complete(runner.cleanup())
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.close()
+        asyncio.set_event_loop(current_loop)
+
+
+@pytest.fixture
+def fake_base_url(fake_server: FakeServer) -> str:
+    """Return the base URL for the in-process aiohttp test server."""
+
+    return fake_server.base_url

--- a/tests/test_network_retry.py
+++ b/tests/test_network_retry.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from typing import Any
+
+import pytest
+
+aiohttp = pytest.importorskip('aiohttp')
+pytest.importorskip('aiohttp_retry')
+
+from aiohttp import ClientResponseError, ClientTimeout
+from aiohttp_retry import ExponentialRetry
+
+from aiochainscan.network import Network
+
+
+class StubUrlBuilder:
+    """Minimal UrlBuilder replacement pointing to a fixed endpoint."""
+
+    def __init__(self, url: str) -> None:
+        self.API_URL = url
+
+    @staticmethod
+    def filter_and_sign(
+        params: dict[str, Any] | None, headers: dict[str, str] | None
+    ) -> tuple[dict[str, Any], dict[str, str]]:
+        return dict(params or {}), dict(headers or {})
+
+
+class CountingThrottler:
+    """Deterministic throttler enforcing a hard concurrency ceiling."""
+
+    def __init__(self, limit: int) -> None:
+        self._limit = limit
+        self._active = 0
+        self.max_seen = 0
+        self._lock = asyncio.Lock()
+
+    async def __aenter__(self) -> "CountingThrottler":
+        while True:
+            async with self._lock:
+                if self._active < self._limit:
+                    self._active += 1
+                    self.max_seen = max(self.max_seen, self._active)
+                    break
+            await asyncio.sleep(0)
+        return self
+
+    async def __aexit__(self, *_: Any) -> None:
+        async with self._lock:
+            self._active -= 1
+
+
+async def _retry_after_honored_once(fake_server: Any) -> None:
+    builder = StubUrlBuilder(f'{fake_server.base_url}/429_once')
+    retry_options = ExponentialRetry(attempts=2, statuses={429})
+    network = Network(
+        builder,
+        timeout=ClientTimeout(total=5),
+        retry_options=retry_options,
+        use_cffi=False,
+        loop=fake_server.loop,
+    )
+    try:
+        start = time.perf_counter()
+        payload = await network.get()
+        elapsed = time.perf_counter() - start
+    finally:
+        await network.close()
+
+    assert payload == {'ok': True}
+    assert fake_server.state['429_once'] == 2
+    assert elapsed >= 1.0
+    assert elapsed < 2.5
+
+
+async def _retry_sustained_429(fake_server: Any) -> None:
+    builder = StubUrlBuilder(f'{fake_server.base_url}/429_sustained')
+    retry_options = ExponentialRetry(attempts=3, statuses={429})
+    network = Network(
+        builder,
+        timeout=ClientTimeout(total=5),
+        retry_options=retry_options,
+        use_cffi=False,
+        loop=fake_server.loop,
+    )
+    try:
+        with pytest.raises(ClientResponseError) as exc_info:
+            await network.get()
+    finally:
+        await network.close()
+
+    err = exc_info.value
+    assert err.status == 429
+    assert err.headers.get('Retry-After') == '2'
+    assert fake_server.state['429_sustained'] == 3
+
+
+async def _timeout_raises(fake_server: Any) -> None:
+    builder = StubUrlBuilder(f'{fake_server.base_url}/timeout')
+    network = Network(
+        builder,
+        timeout=ClientTimeout(total=0.05),
+        retry_options=ExponentialRetry(attempts=1),
+        use_cffi=False,
+        loop=fake_server.loop,
+    )
+    try:
+        with pytest.raises(asyncio.TimeoutError):
+            await network.get()
+    finally:
+        await network.close()
+
+    assert fake_server.state['timeout'] == 1
+
+
+async def _no_retry_on_non_retryable(fake_server: Any) -> None:
+    builder = StubUrlBuilder(f'{fake_server.base_url}/forbidden')
+    retry_options = ExponentialRetry(attempts=4, statuses={429})
+    network = Network(
+        builder,
+        timeout=ClientTimeout(total=5),
+        retry_options=retry_options,
+        use_cffi=False,
+        loop=fake_server.loop,
+    )
+    try:
+        with pytest.raises(ClientResponseError) as exc_info:
+            await network.get()
+    finally:
+        await network.close()
+
+    assert exc_info.value.status == 403
+    assert fake_server.state['forbidden'] == 1
+
+
+async def _throttler_enforces(fake_server: Any) -> None:
+    builder = StubUrlBuilder(f'{fake_server.base_url}/ok')
+    throttler = CountingThrottler(limit=2)
+    network = Network(
+        builder,
+        timeout=ClientTimeout(total=5),
+        throttler=throttler,
+        retry_options=ExponentialRetry(attempts=1),
+        use_cffi=False,
+        loop=fake_server.loop,
+    )
+
+    async def do_request() -> Any:
+        return await network.get()
+
+    try:
+        await asyncio.gather(*(do_request() for _ in range(5)))
+    finally:
+        await network.close()
+
+    assert fake_server.state['ok_total'] == 5
+    assert fake_server.state['ok_max'] <= 2
+    assert throttler.max_seen <= 2
+
+
+def test_retry_after_honored_once(fake_server: Any) -> None:
+    fake_server.run(_retry_after_honored_once(fake_server))
+
+
+def test_retry_sustained_429_gives_rate_limit_error(fake_server: Any) -> None:
+    fake_server.run(_retry_sustained_429(fake_server))
+
+
+def test_timeout_raises_timeout_error(fake_server: Any) -> None:
+    fake_server.run(_timeout_raises(fake_server))
+
+
+def test_no_retry_on_non_retryable_4xx(fake_server: Any) -> None:
+    fake_server.run(_no_retry_on_non_retryable(fake_server))
+
+
+def test_throttler_enforces_concurrency(fake_server: Any) -> None:
+    fake_server.run(_throttler_enforces(fake_server))


### PR DESCRIPTION
## Summary
- add deterministic aiohttp-backed fixtures for exercising retry and throttling flows
- add network retry test suite covering retry-after, sustained 429, timeout, non-retryable errors, and throttling limits

## Testing
- pytest tests/test_network_retry.py -q

------
https://chatgpt.com/codex/tasks/task_e_68e60f91f220832bab5641e5c2a498cb