### PR TITLE
Add PyPI Trusted Publisher configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,8 +128,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: github.event_name == 'release' && github.event.action == 'published'
+    environment: pypi
     permissions:
       id-token: write
+      contents: read
 
     steps:
       - name: Download build artifacts


### PR DESCRIPTION
- Add environment: pypi for deployment protection
- Add contents: read permission for security
- Ready for automated PyPI publishing via GitHub releases